### PR TITLE
add flowbroker permissions to call k8s api

### DIFF
--- a/roles/flowbroker/templates/flowbroker_role.yaml.j2
+++ b/roles/flowbroker/templates/flowbroker_role.yaml.j2
@@ -6,7 +6,7 @@ metadata:
 rules:
 - apiGroups: ["extensions"]
   resources: ["deployments"]
-  verbs: ["get", "list", "create"]
+  verbs: ["get", "list", "create", "patch", "delete"]
 - apiGroups: [""]
   resources: ["services"]
-  verbs: ["get", "list", "create"]
+  verbs: ["get", "list", "create", "patch", "delete"]


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
  * [ ] Tests for the changes have been added (for bug fixes / features)
  * [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix flowbroker permissions to call patch and delete on Kubernetes API

* **What is the current behavior?** (You can also link to an open issue here)
Flowbroker has not permissions to call patch and delete on Kubernetes API

* **What is the new behavior (if this is a feature change)?**
Flowbroker has permissions to call patch and delete on Kubernetes API

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
Yes, this PR is connected to dojot/dojot#1348

* **Other information**:
