### PR TITLE
enable topology key

### DIFF
--- a/roles/vernemq/templates/vernemq_service.yaml.j2
+++ b/roles/vernemq/templates/vernemq_service.yaml.j2
@@ -22,4 +22,6 @@ spec:
   selector:
     app: vernemq
     vernemq: k8s
+  topologyKeys:
+    - "kubernetes.io/hostname"
   sessionAffinity: ClientIP


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
  * [ ] Tests for the changes have been added (for bug fixes / features)
  * [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Enable topology keys on VerneMq Cluster IP service

* **What is the current behavior?** (You can also link to an open issue here)
The service did not use service topology

* **What is the new behavior (if this is a feature change)?**
VerneMq Cluster IP service uses service topology

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
Yes, this PR is related to dojot/dojot#1495

* **Other information**:
This change only works on k8s 1.17
