### PR TITLE
NodePort 1883 will not be mapped if insecure mode is disabled

### DIFF
--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -24,6 +24,7 @@ defaults
         timeout server 300000ms
         default-server init-addr last,libc,none
 
+{% if dojot_insecure_mqtt %}
 listen mqtt
         mode tcp
         option tcplog
@@ -33,6 +34,7 @@ listen mqtt
 {% for node in groups['mqtt_nodes'] | default([]) %}
         server mqtt-{{ loop.index }} {{ node }}:{{ dojot_nodeports.mqtt }} check inter 1000ms fall 3 rise 5
 {% endfor %}
+{% endif %}
 
 listen mqtts
         mode tcp

--- a/roles/iotagent-mosca/templates/iotagent_mosca_service.yaml.j2
+++ b/roles/iotagent-mosca/templates/iotagent_mosca_service.yaml.j2
@@ -9,10 +9,12 @@ spec:
   externalTrafficPolicy: Local
   type: NodePort
   ports:
+{% if dojot_insecure_mqtt %}
     - name: mqtt-insecure
       port: 1883
 {% if dojot_fixed_nodeports_enabled %}
       nodePort: {{ dojot_nodeports.mqtt }}
+{% endif %}
 {% endif %}
     - name: mqtt-secure
       port: 8883

--- a/roles/nginx/tasks/main.yaml
+++ b/roles/nginx/tasks/main.yaml
@@ -58,8 +58,17 @@
     - coaps
     - file_server
     - file_servers
-    - mqtt
     - mqtts
+
+- name: Copy mqtt config files
+  when: {{ dojot_insecure_mqtt }}
+  become: yes
+  template:
+    src: "mqtt.conf.j2"
+    dest: "/etc/nginx/stream-conf.d/dojot_mqtt.conf"
+    owner: root
+    group: root
+    mode: 0644
 
 - name: restart nginx
   become: yes

--- a/roles/vernemq/templates/vernemq_external_service.yaml.j2
+++ b/roles/vernemq/templates/vernemq_external_service.yaml.j2
@@ -8,10 +8,12 @@ spec:
   selector:
     vernemq: k8s
   ports:
+{% if dojot_insecure_mqtt %}
     - name: mqtt
       port: 1883
 {% if dojot_fixed_nodeports_enabled %}
       nodePort: {{ dojot_nodeports.mqtt }}
+{% endif %}
 {% endif %}
     - name: mqtts
       port: 8883


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
  * [ ] Tests for the changes have been added (for bug fixes / features)
  * [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
NodePort 1883 (insecure mqtt port) is mapped only when insecure mode is enabled.

* **What is the current behavior?** (You can also link to an open issue here)
NodePort 1883 (insecure mqtt port) is mapped even when secure mode is enabled.

* **What is the new behavior (if this is a feature change)?**
NodePort 1883 (insecure mqtt port) is mapped only when insecure mode is enabled.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
Yes, this PR is connected to dojot/dojot#1680

* **Other information**:
