### PR TITLE
Separation of EJBCA from x509-identity-mgmt and volume sharing

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -302,6 +302,13 @@
       - lwm2m
       - 100k
 
+    - role: x509-ejbca
+      tags:
+      - vernemq
+      - mosca
+      - lwm2m
+      - 100k
+
     - role: x509-identity-mgmt
       tags:
       - vernemq

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -140,6 +140,8 @@ before deploying dojot
 * *dojot_psql_ejbca_passwd*: EJBCA PostgreSQL database password. Defaults to **ejbca**.
 * *dojot_x509_identity_mgmt_version*: Version of the x509 Identity Management container. Defaults to **dojot_version**.
 * *dojot_x509_identity_mgmt_replicas*: Number of replicas. Beware that you must configure a volume if you want more than one instance. Defaults to **1**.
+* *dojot_x509_ejbca_version*: Version of the x509 EJBCA container. Defaults to **dojot_version**.
+* *dojot_x509_ejbca_replicas*: Number of replicas. Beware that you must configure a volume if you want more than one instance. Defaults to **1**.
 
 ### - Kafka Loopback
 

--- a/inventories/example_local/group_vars/all/dojot.yaml
+++ b/inventories/example_local/group_vars/all/dojot.yaml
@@ -17,6 +17,8 @@ dojot_psql_persistent_volumes: false
 dojot_influxdb_persistent_volumes: false
 # Whether it should create a volume for x509 Identity Management
 dojot_x509_identity_mgmt_persistent_volumes: false
+# Whether it should create a volume for x509 EJBCA
+dojot_x509_ejbca_persistent_volumes: false
 # Whether it should create a volume for MongoDB
 dojot_mongodb_persistent_volumes: false
 # Whether it should create a volume for Minio
@@ -45,6 +47,8 @@ dojot_vernemq_replicas: 1
 dojot_bridges_replicas: 1
 # Number of x509 Identity Management replicas
 dojot_x509_identity_mgmt_replicas: 1
+# Number of x509 EJBCA replicas
+dojot_x509_ejbca_replicas: 1
 
 # Enable Kafka WS TLS support, the service must have a configured volume with the certificates inside
 dojot_kafka_ws_enable_tls: false

--- a/local_storage_example/volumes/x509_ejbca.yaml
+++ b/local_storage_example/volumes/x509_ejbca.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-pv-x509-ejbca
+  labels:
+    type: local
+    app: dojot
+    name: x509-ejbca
+spec:
+  capacity:
+    storage: 10Mi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-storage
+  local:
+    path: /mnt/data/ejbca
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: dojot.components/group
+          operator: In
+          values:
+          - x509

--- a/local_storage_example/volumes/x509_ejbca_tls.yaml
+++ b/local_storage_example/volumes/x509_ejbca_tls.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: local-pv-x509-identity-mgmt
+  name: local-pv-x509-ejbca-tls
   labels:
     type: local
     app: dojot
-    name: x509-identity-mgmt
+    name: x509-ejbca-tls
 spec:
   capacity:
     storage: 10Mi
@@ -14,7 +14,7 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   storageClassName: local-storage
   local:
-    path: /mnt/data/ejbca
+    path: /mnt/data/ejbca-tls
   nodeAffinity:
     required:
       nodeSelectorTerms:

--- a/roles/x509-ejbca/defaults/main.yaml
+++ b/roles/x509-ejbca/defaults/main.yaml
@@ -1,0 +1,5 @@
+dojot_x509_ejbca_version: "{{ dojot_version }}"
+dojot_x509_ejbca_volume_size: 10Mi
+
+dojot_psql_ejbca_user: "ejbca"
+dojot_psql_ejbca_passwd: "ejbca"

--- a/roles/x509-ejbca/tasks/main.yaml
+++ b/roles/x509-ejbca/tasks/main.yaml
@@ -1,0 +1,27 @@
+- name: dojot - x509 EJBCA Objects
+  k8s:
+    kubeconfig: "{{ dojot_kubeconfig_file_path | default(omit) }}"
+    state: present
+    definition: "{{ item }}"
+  register: result
+  until: result.failed == 0
+  retries: 30
+  delay: 10
+  loop:
+  - "{{ lookup('template', 'x509_ejbca_secrets.yaml.j2') | from_yaml }}"
+  - "{{ lookup('template', 'x509_ejbca_deployment.yaml.j2') | from_yaml }}"
+  - "{{ lookup('template', 'x509_ejbca_service.yaml.j2') | from_yaml }}"
+
+- name: dojot - x509 EJBCA Persistent Volume Claim
+  when: "{{ dojot_x509_ejbca_persistent_volumes }}"
+  k8s:
+    kubeconfig: "{{ dojot_kubeconfig_file_path | default(omit) }}"
+    state: present
+    definition: "{{ item }}"
+  register: result
+  until: result.failed == 0
+  retries: 30
+  delay: 10
+  loop:
+  - "{{ lookup('template', 'x509_ejbca_pvc.yaml.j2') | from_yaml }}"
+  - "{{ lookup('template', 'x509_ejbca_tls_pvc.yaml.j2') | from_yaml }}"

--- a/roles/x509-ejbca/templates/x509_ejbca_deployment.yaml.j2
+++ b/roles/x509-ejbca/templates/x509_ejbca_deployment.yaml.j2
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: x509-ejbca
+  namespace: {{ dojot_namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: dojot
+      name: x509-ejbca
+  replicas: {{ dojot_x509_ejbca_replicas }}
+  template:
+    metadata:
+      labels:
+        app: dojot
+        name: x509-ejbca
+    spec:
+      securityContext:
+        fsGroup: 10001
+      hostname: "x509-ejbca"
+      #subdomain: ""
+      restartPolicy: Always
+      containers:
+      - name: x509-ejbca
+        image: dojot/ejbca:{{ dojot_x509_ejbca_version  }}
+        readinessProbe:
+          httpGet:
+            path: /ejbca/publicweb/healthcheck/ejbcahealth
+            port: 8080
+          periodSeconds: 20
+          timeoutSeconds: 5
+        env:
+        - name: EJBCA_EXTERNAL_ACCESS
+          value: "true"
+        - name: DATABASE_JDBC_URL
+          value: "jdbc:postgresql://postgres:5432/ejbca?characterEncoding=UTF-8"
+        - name: DATABASE_USER
+          valueFrom:
+            secretKeyRef:
+              name: x509-ejbca-secret
+              key: user
+        - name: DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: x509-ejbca-secret
+              key: password
+{% if dojot_x509_ejbca_persistent_volumes %}
+        volumeMounts:
+        - name: x509-ejbca
+          mountPath: /mnt/persistent
+        - name: x509-ejbca-tls
+          mountPath: /opt/tls
+      volumes:
+      - name: x509-ejbca
+        persistentVolumeClaim:
+          claimName: x509-ejbca
+      - name: x509-ejbca-tls
+        persistentVolumeClaim:
+          claimName: x509-ejbca-tls
+{% endif %}
+{% if dojot_enable_node_affinity %}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: dojot.components/group
+                operator: In
+                values:
+                - "{{ dojot_node_label.x509 }}"
+{% endif %}

--- a/roles/x509-ejbca/templates/x509_ejbca_pvc.yaml.j2
+++ b/roles/x509-ejbca/templates/x509_ejbca_pvc.yaml.j2
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: x509-ejbca
+  namespace: {{ dojot_namespace }}
+  labels:
+    app: dojot
+    name: x509-ejbca
+spec:
+  selector:
+    matchLabels:
+      app: dojot
+      name: x509-ejbca
+  accessModes:
+    - ReadWriteMany
+  storageClassName: {{ dojot_storage_class_name }}
+  resources:
+    requests:
+      storage: {{ dojot_x509_ejbca_volume_size }}

--- a/roles/x509-ejbca/templates/x509_ejbca_secrets.yaml.j2
+++ b/roles/x509-ejbca/templates/x509_ejbca_secrets.yaml.j2
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: x509-ejbca-secret
+  namespace: {{ dojot_namespace }}
+type: Opaque
+data:
+  user: {{ dojot_psql_ejbca_user | b64encode }}
+  password: {{ dojot_psql_ejbca_passwd | b64encode }}

--- a/roles/x509-ejbca/templates/x509_ejbca_service.yaml.j2
+++ b/roles/x509-ejbca/templates/x509_ejbca_service.yaml.j2
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: x509-ejbca
+  namespace: {{ dojot_namespace }}
+spec:
+  type: ClusterIP
+  selector:
+    app: dojot
+    name: x509-ejbca
+  ports:
+  - name: x509-ejbca
+    port: 8443
+  - name: x509-ejbca-hc
+    port: 8080

--- a/roles/x509-ejbca/templates/x509_ejbca_tls_pvc.yaml.j2
+++ b/roles/x509-ejbca/templates/x509_ejbca_tls_pvc.yaml.j2
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: x509-identity-mgmt
+  name: x509-ejbca-tls
   namespace: {{ dojot_namespace }}
   labels:
     app: dojot
-    name: x509-identity-mgmt
+    name: x509-ejbca-tls
 spec:
   selector:
     matchLabels:
       app: dojot
-      name: x509-identity-mgmt
+      name: x509-ejbca-tls
   accessModes:
     - ReadWriteMany
   storageClassName: {{ dojot_storage_class_name }}
   resources:
     requests:
-      storage: {{ dojot_x509_identity_management_volume_size }}
+      storage: {{ dojot_x509_ejbca_volume_size }}

--- a/roles/x509-identity-mgmt/tasks/main.yaml
+++ b/roles/x509-identity-mgmt/tasks/main.yaml
@@ -12,15 +12,3 @@
   - "{{ lookup('template', 'x509_identity_mgmt_deployment.yaml.j2') | from_yaml }}"
   - "{{ lookup('template', 'x509_identity_mgmt_service.yaml.j2') | from_yaml }}"
 
-- name: dojot - x509 Identity Management Persistent Volume Claim
-  when: "{{ dojot_x509_identity_mgmt_persistent_volumes }}"
-  k8s:
-    kubeconfig: "{{ dojot_kubeconfig_file_path | default(omit) }}"
-    state: present
-    definition: "{{ item }}"
-  register: result
-  until: result.failed == 0
-  retries: 30
-  delay: 10
-  loop:
-  - "{{ lookup('template', 'x509_identity_mgmt_pvc.yaml.j2') | from_yaml }}"

--- a/roles/x509-identity-mgmt/templates/x509_identity_mgmt_deployment.yaml.j2
+++ b/roles/x509-identity-mgmt/templates/x509_identity_mgmt_deployment.yaml.j2
@@ -17,45 +17,33 @@ spec:
     spec:
       securityContext:
         fsGroup: 10001
-      hostname: "x509-identity-mgmt"
-      #subdomain: "dojot.iot"
       restartPolicy: Always
       containers:
       - name: x509-identity-mgmt
         image: dojot/x509-identity-mgmt:{{ dojot_x509_identity_mgmt_version  }}
         readinessProbe:
           httpGet:
-            path: /healthcheck
-            port: 3000
+            path: /health
+            port: 9000
           periodSeconds: 20
           timeoutSeconds: 5
         env:
-        - name: DATABASE_JDBC_URL
-          value: "jdbc:postgresql://postgres:5432/ejbca?characterEncoding=UTF-8"
-        - name: DATABASE_USER
-          valueFrom:
-            secretKeyRef:
-              name: x509-identity-mgmt-secret
-              key: user
-        - name: DATABASE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: x509-identity-mgmt-secret
-              key: password
-        - name: EJBCA_PERFORM_DOJOT_SETUP
-          value: "true"
         - name: NODE_ENV
           value: "production"
-        - name: MONGO_URI
+        - name: X509IDMGMT_MONGO_CONN_URI
           value: "mongodb://mongodb:27017/x509-identity-mgmt"
+        - name: X509IDMGMT_EJBCA_HEALTHCHECK_URL
+          value: "http://x509-ejbca:8080/ejbca/publicweb/healthcheck/ejbcahealth"
+        - name: X509IDMGMT_EJBCA_WSDL
+          value: "https://x509-ejbca:8443/ejbca/ejbcaws/ejbcaws?wsdl"
 {% if dojot_x509_identity_mgmt_persistent_volumes %}
         volumeMounts:
-        - name: x509-identity-mgmt
-          mountPath: /mnt/persistent
+        - name: x509-ejbca-tls
+          mountPath: /opt/tls
       volumes:
-      - name: x509-identity-mgmt
+      - name: x509-ejbca-tls
         persistentVolumeClaim:
-          claimName: x509-identity-mgmt
+          claimName: x509-ejbca-tls
 {% endif %}
 {% if dojot_enable_node_affinity %}
       affinity:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
  * [ ] Tests for the changes have been added (for bug fixes / features)
  * [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

The x509-identity-mgmt container also performed the EJBCA internally.

* **What is the new behavior (if this is a feature change)?**

EJBCA has its own container again, but now it shares a volume with x509-identity-mgmt.
The volume is used to store the .12 file that gives x509-identity-mgmt access to the EJBCA API.
In the future, it would be interesting to keep .p12 in a secret that only the two Pods had access to. A kind of secret in the form of a mount point.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)

dojot/dojot#1964
dojot/docker-compose#220

* **Other information**:

This PR does not need to be approved, but it serves as a reference to know what has been changed in the Pods.