### PR TITLE
[v0.6.0] kafka-ws fix readiness and liveness prove

### DIFF
--- a/roles/kafka-ws/templates/kafka_ws_deployment.yaml.j2
+++ b/roles/kafka-ws/templates/kafka_ws_deployment.yaml.j2
@@ -28,18 +28,32 @@ spec:
         # by Kubernetes
         readinessProbe:
           httpGet:
-            path: /healthcheck
-            port: 8080
+            path: /ready
+            port: 9000
 {% if dojot_kafka_ws_enable_tls %}
             scheme: HTTPS
 {% endif %}
+          initialDelaySeconds: 15
+          failureThresold: 1
           periodSeconds: 20
+          successThreshold: 1
           timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: 9000
+          failureThresold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 3
         env:
         - name: KAFKA_WS_CONSUMER_METADATA_BROKER_LIST
           value: "kafka-server:{{ dojot_kafka_port }}"
         - name: KAFKA_WS_SERVER_PORT
           value: "{{ dojot_kafka_ws_port }}"
+        - name: KAFKA_WS_REDIS_HOST
+          value: "kafka-ws-redis"
         - name: KAFKA_WS_REDIS_PORT
           value: "{{ dojot_kafka_ws_redis_port }}"
         - name: KAFKA_WS_SERVER_TLS


### PR DESCRIPTION
fixed readiness and liveness prob for kafka-ws
updated redis host default env variable for kafka-ws

* **Please check if the PR fulfills these requirements**
  * [ ] Tests for the changes have been added (for bug fixes / features)
  * [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix
* **What is the current behavior?** (You can also link to an open issue here)

* **What is the new behavior (if this is a feature change)?**

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
* #dojot/dojot/1973

* **Other information**:
