### PR TITLE
[k8s] Fixing docker version in the k8s playbook

### DIFF
--- a/roles/k8s-cluster/all-nodes/tasks/main.yaml
+++ b/roles/k8s-cluster/all-nodes/tasks/main.yaml
@@ -1,6 +1,8 @@
 ---
 
 - name: Install packages that allow apt to be used over HTTPS
+  tags:
+  - docker
   become: yes
   apt:
     name: "{{ packages }}"
@@ -16,18 +18,24 @@
     - software-properties-common
 
 - name: Add an apt signing key for Docker
+  tags:
+  - docker
   become: yes
   apt_key:
     url: https://download.docker.com/linux/ubuntu/gpg
     state: present
 
 - name: Add apt repository for stable version
+  tags:
+  - docker
   become: yes
   apt_repository:
-    repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
+    repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_facts.lsb.codename }} stable
     state: present
 
 - name: Install docker and its dependecies
+  tags:
+  - docker
   become: yes
   apt:
     name: "{{ packages }}"
@@ -35,13 +43,15 @@
     update_cache: yes
   vars:
     packages:
-    - docker-ce
-    - docker-ce-cli
-    - containerd.io
+    - docker-ce=5:19.03.14~3-0~ubuntu-{{ ansible_facts.lsb.codename }}
+    - docker-ce-cli=5:19.03.14~3-0~ubuntu-{{ ansible_facts.lsb.codename }}
+    - containerd.io=1.2.10-3
   notify:
     - docker status
 
 - name: Docker daemon settings
+  tags:
+  - docker
   become: yes
   template:
     src: docker-daemon.json.j2


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
  * [ ] Tests for the changes have been added (for bug fixes / features)
  * [ ] Docs have been added / updated (for bug fixes / features)

* **What is the current behavior?** (You can also link to an open issue here)
When we set up the k8s cluster with the dojot playbook, the docker version that will be installed on the pods will be "latest"

* **What is the new behavior (if this is a feature change)?**
When we set up the k8s cluster with the dojot playbook, the docker version that will be installed on the pods will be `19.03.4` as specified in the k8s documentation

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
Yes, this PR is connected to dojot/dojot#1898