### PR TITLE
Separation of EJBCA from x509-identity-mgmt and volume sharing

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -193,3 +193,7 @@
     - role: x509-identity-mgmt
       tags:
       - 100k
+
+    - role: x509-ejbca
+      tags:
+      - 100k

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -134,6 +134,8 @@ before deploying dojot
 * *dojot_psql_ejbca_passwd*: EJBCA PostgreSQL database password. Defaults to **ejbca**.
 * *dojot_x509_identity_mgmt_version*: Version of the x509 Identity Management container. Defaults to **dojot_version**.
 * *dojot_x509_identity_mgmt_replicas*: Number of replicas. Beware that you must configure a volume if you want more than one instance. Defaults to **1**.
+* *dojot_x509_ejbca_version*: Version of the x509 EJBCA container. Defaults to **dojot_version**.
+* *dojot_x509_ejbca_replicas*: Number of replicas. Beware that you must configure a volume if you want more than one instance. Defaults to **1**.
 
 ### - Kafka Loopback
 

--- a/inventories/example_local/group_vars/all/dojot.yaml
+++ b/inventories/example_local/group_vars/all/dojot.yaml
@@ -23,6 +23,8 @@ dojot_vernemq_replicas: 1
 dojot_bridges_replicas: 1
 # Number of x509 Identity Management replicas
 dojot_x509_identity_mgmt_replicas: 1
+# Number of x509 EJBCA replicas
+dojot_x509_ejbca_replicas: 1
 
 # Enable Kafka WS TLS support, the service must have a configured volume with the certificates inside
 dojot_kafka_ws_enable_tls: false

--- a/roles/volumes/x509-ejbca/tasks/main.yaml
+++ b/roles/volumes/x509-ejbca/tasks/main.yaml
@@ -18,6 +18,6 @@
   retries: 30
   delay: 10
   loop:
-  - "{{ lookup('template', 'x509_identity_mgmt.yaml.j2') | from_yaml }}"
+  - "{{ lookup('template', 'x509_ejbca.yaml.j2') | from_yaml }}"
   when: (dojot_storage_class_name == "local-storage") and
         ('master_nodes' in {{ group_names }})

--- a/roles/volumes/x509-ejbca/templates/x509_ejbca.yaml.j2
+++ b/roles/volumes/x509-ejbca/templates/x509_ejbca.yaml.j2
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: local-pv-x509-identity-mgmt
+  name: local-pv-x509-ejbca
   labels:
     type: local
     app: dojot
-    name: x509-identity-mgmt
+    name: x509-ejbca
 spec:
   capacity:
     storage: 10Mi

--- a/roles/volumes/x509-identity-mgmt/tasks/main.yaml
+++ b/roles/volumes/x509-identity-mgmt/tasks/main.yaml
@@ -1,0 +1,23 @@
+---
+
+- name: Create x509-identity-mgmt directory if it does not exists
+  become: true
+  file:
+    path: "{{ dojot_volume_directory }}/x509-identity-mgmt"
+    state: directory
+  when: (dojot_storage_class_name == "local-storage") and
+        ('x509_nodes' in {{ group_names }})
+
+- name: Create x509_identity_mgmt volume
+  k8s:
+    kubeconfig: "{{ dojot_kubeconfig_file_path | default(omit) }}"
+    state: present
+    definition: "{{ item }}"
+  register: result
+  until: result.failed == 0
+  retries: 30
+  delay: 10
+  loop:
+  - "{{ lookup('template', 'x509_identity_mgmt.yaml.j2') | from_yaml }}"
+  when: (dojot_storage_class_name == "local-storage") and
+        ('master_nodes' in {{ group_names }})

--- a/roles/volumes/x509-identity-mgmt/templates/x509_identity_mgmt.yaml.j2
+++ b/roles/volumes/x509-identity-mgmt/templates/x509_identity_mgmt.yaml.j2
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-pv-x509-identity-mgmt
+  labels:
+    type: local
+    app: dojot
+    name: x509-identity-mgmt
+spec:
+  capacity:
+    storage: 10Mi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: {{ dojot_storage_class_name }}
+  local:
+    path: {{ dojot_volume_directory }}/x509-identity-mgmt
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: dojot.components/x509
+          operator: In
+          values:
+          - "enabled"

--- a/roles/x509-ejbca/defaults/main.yaml
+++ b/roles/x509-ejbca/defaults/main.yaml
@@ -1,0 +1,5 @@
+dojot_x509_ejbca_version: "{{ dojot_version }}"
+dojot_x509_ejbca_volume_size: 10Mi
+
+dojot_psql_ejbca_user: "ejbca"
+dojot_psql_ejbca_passwd: "ejbca"

--- a/roles/x509-ejbca/tasks/main.yaml
+++ b/roles/x509-ejbca/tasks/main.yaml
@@ -1,4 +1,4 @@
-- name: dojot - x509 Identity Management Objects
+- name: dojot - x509 EJBCA Objects
   k8s:
     kubeconfig: "{{ dojot_kubeconfig_file_path | default(omit) }}"
     state: present
@@ -8,10 +8,11 @@
   retries: 30
   delay: 10
   loop:
-  - "{{ lookup('template', 'x509_identity_mgmt_deployment.yaml.j2') | from_yaml }}"
-  - "{{ lookup('template', 'x509_identity_mgmt_service.yaml.j2') | from_yaml }}"
+  - "{{ lookup('template', 'x509_ejbca_secrets.yaml.j2') | from_yaml }}"
+  - "{{ lookup('template', 'x509_ejbca_deployment.yaml.j2') | from_yaml }}"
+  - "{{ lookup('template', 'x509_ejbca_service.yaml.j2') | from_yaml }}"
 
-- name: dojot - x509 Identity Management Persistent Volume Claim
+- name: dojot - x509 EJBCA Persistent Volume Claim
   k8s:
     kubeconfig: "{{ dojot_kubeconfig_file_path | default(omit) }}"
     state: present
@@ -21,4 +22,4 @@
   retries: 30
   delay: 10
   loop:
-  - "{{ lookup('template', 'x509_identity_mgmt_pvc.yaml.j2') | from_yaml }}"
+  - "{{ lookup('template', 'x509_ejbca_pvc.yaml.j2') | from_yaml }}"

--- a/roles/x509-ejbca/templates/x509_ejbca_deployment.yaml.j2
+++ b/roles/x509-ejbca/templates/x509_ejbca_deployment.yaml.j2
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: x509-ejbca
+  namespace: {{ dojot_namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: dojot
+      name: x509-ejbca
+  replicas: {{ dojot_x509_ejbca_replicas }}
+  template:
+    metadata:
+      labels:
+        app: dojot
+        name: x509-ejbca
+    spec:
+      securityContext:
+        fsGroup: 10001
+      hostname: "x509-ejbca"
+      restartPolicy: Always
+      containers:
+      - name: x509-ejbca
+        image: dojot/ejbca:{{ dojot_x509_ejbca_version  }}
+        readinessProbe:
+          httpGet:
+            path: /ejbca/publicweb/healthcheck/ejbcahealth
+            port: 8080
+          periodSeconds: 20
+          timeoutSeconds: 5
+        env:
+        - name: EJBCA_EXTERNAL_ACCESS
+          value: "true"
+        - name: EJBCA_SERVER_CERT_REGEN
+          value: "true"
+        - name: DATABASE_JDBC_URL
+          value: "jdbc:postgresql://postgres:5432/ejbca?characterEncoding=UTF-8"
+        - name: DATABASE_USER
+          valueFrom:
+            secretKeyRef:
+              name: x509-ejbca-secret
+              key: user
+        - name: DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: x509-ejbca-secret
+              key: password
+        volumeMounts:
+        - name: x509-ejbca
+          mountPath: /mnt/persistent
+        - name: x509-identity-mgmt
+          mountPath: /opt/tls
+      volumes:
+      - name: x509-ejbca
+        persistentVolumeClaim:
+          claimName: x509-ejbca
+      - name: x509-identity-mgmt
+        persistentVolumeClaim:
+          claimName: x509-identity-mgmt
+{% if dojot_enable_node_affinity %}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: dojot.components/x509
+                operator: In
+                values:
+                - "enabled"
+{% endif %}

--- a/roles/x509-ejbca/templates/x509_ejbca_pvc.yaml.j2
+++ b/roles/x509-ejbca/templates/x509_ejbca_pvc.yaml.j2
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: x509-ejbca
+  namespace: {{ dojot_namespace }}
+  labels:
+    app: dojot
+    name: x509-ejbca
+spec:
+  selector:
+    matchLabels:
+      app: dojot
+      name: x509-ejbca
+  accessModes:
+    - ReadWriteMany
+  storageClassName: {{ dojot_storage_class_name }}
+  resources:
+    requests:
+      storage: {{ dojot_x509_ejbca_volume_size }}

--- a/roles/x509-ejbca/templates/x509_ejbca_secrets.yaml.j2
+++ b/roles/x509-ejbca/templates/x509_ejbca_secrets.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: x509-identity-mgmt-secret
+  name: x509-ejbca-secret
   namespace: {{ dojot_namespace }}
 type: Opaque
 data:

--- a/roles/x509-ejbca/templates/x509_ejbca_service.yaml.j2
+++ b/roles/x509-ejbca/templates/x509_ejbca_service.yaml.j2
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: x509-ejbca
+  namespace: {{ dojot_namespace }}
+spec:
+  type: ClusterIP
+  selector:
+    app: dojot
+    name: x509-ejbca
+  ports:
+  - name: x509-ejbca
+    port: 8443
+  - name: x509-ejbca-public
+    port: 8080

--- a/roles/x509-identity-mgmt/defaults/main.yaml
+++ b/roles/x509-identity-mgmt/defaults/main.yaml
@@ -1,5 +1,2 @@
 dojot_x509_identity_mgmt_version: "{{ dojot_version }}"
 dojot_x509_identity_management_volume_size: 10Mi
-
-dojot_psql_ejbca_user: "ejbca"
-dojot_psql_ejbca_passwd: "ejbca"

--- a/roles/x509-identity-mgmt/templates/x509_identity_mgmt_deployment.yaml.j2
+++ b/roles/x509-identity-mgmt/templates/x509_identity_mgmt_deployment.yaml.j2
@@ -17,40 +17,26 @@ spec:
     spec:
       securityContext:
         fsGroup: 10001
-      hostname: "x509-identity-mgmt"
-      #subdomain: "dojot.iot"
       restartPolicy: Always
       containers:
       - name: x509-identity-mgmt
         image: dojot/x509-identity-mgmt:{{ dojot_x509_identity_mgmt_version  }}
         readinessProbe:
           httpGet:
-            path: /healthcheck
-            port: 3000
+            path: /health
+            port: 9000
           periodSeconds: 20
           timeoutSeconds: 5
         env:
-        - name: DATABASE_JDBC_URL
-          value: "jdbc:postgresql://postgres:5432/ejbca?characterEncoding=UTF-8"
-        - name: DATABASE_USER
-          valueFrom:
-            secretKeyRef:
-              name: x509-identity-mgmt-secret
-              key: user
-        - name: DATABASE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: x509-identity-mgmt-secret
-              key: password
-        - name: EJBCA_PERFORM_DOJOT_SETUP
-          value: "true"
         - name: NODE_ENV
           value: "production"
-        - name: MONGO_URI
-          value: "mongodb://mongodb:27017/x509-identity-mgmt"
+        - name: X509IDMGMT_KAFKA_PRODUCER_METADATA_BROKER_LIST
+          value: "kafka-server:9092"
+        - name: X509IDMGMT_KAFKA_CONSUMER_METADATA_BROKER_LIST
+          value: "kafka-server:9092"
         volumeMounts:
         - name: x509-identity-mgmt
-          mountPath: /mnt/persistent
+          mountPath: /opt/tls
       volumes:
       - name: x509-identity-mgmt
         persistentVolumeClaim:

--- a/volume.yaml
+++ b/volume.yaml
@@ -28,7 +28,8 @@
   tags:
   - volumes
   roles:
-    - role: volumes/ejbca
+    - role: volumes/x509-ejbca
+    - role: volumes/x509-identity-mgmt
 
 - hosts: master_nodes
   gather_facts: true
@@ -44,5 +45,6 @@
     - role: volumes/kafka-ws
     - role: volumes/kafka
     - role: volumes/zookeeper
-    - role: volumes/ejbca
+    - role: volumes/x509-ejbca
+    - role: volumes/x509-identity-mgmt
     - role: volumes/influxdb


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
  * [ ] Tests for the changes have been added (for bug fixes / features)
  * [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

The x509-identity-mgmt container also performed the EJBCA internally.

* **What is the new behavior (if this is a feature change)?**

EJBCA has its own container again, but now it shares a volume with x509-identity-mgmt.
The volume is used to store the .12 file that gives x509-identity-mgmt access to the EJBCA API.
In the future, it would be interesting to keep .p12 in a secret that only the two Pods had access to. A kind of secret in the form of a mount point.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)

dojot/dojot#1964
dojot/docker-compose#220

* **Other information**:

This PR does not need to be approved, but it serves as a reference to know what has been changed in the Pods.