### PR TITLE
[dev] Implement log file rotation

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -188,7 +188,8 @@ before deploying dojot
 ### - Kubernetes Cluster
 
 * *k8s_version*: Version of the Kubernetes cluster. Defaults to *1.17.3-00*.
-* *docker_log_size*: The maximum size of the log before it is rolled. Defaults to *100m*.
+* *docker_log_size*: The maximum size of the log before it is rolled. Defaults to *20m*.
+* *docker_log_files_amount*: The maximum amount of log files before it is rolled. Defaults to *5*.
 
 ### - HAProxy
 

--- a/roles/k8s-cluster/all-nodes/defaults/main.yaml
+++ b/roles/k8s-cluster/all-nodes/defaults/main.yaml
@@ -1,4 +1,5 @@
 k8s_version: 1.19.8-00
 docker_version: 19.03.14~3-0~ubuntu
-docker_log_size: 100m
+docker_log_size: 20m
+docker_log_files_amount: '5'
 containerd_version: 1.2.13-2

--- a/roles/k8s-cluster/all-nodes/templates/docker-daemon.json.j2
+++ b/roles/k8s-cluster/all-nodes/templates/docker-daemon.json.j2
@@ -2,7 +2,8 @@
   "exec-opts": ["native.cgroupdriver=systemd"],
   "log-driver": "json-file",
   "log-opts": {
-    "max-size": "{{ docker_log_size }}"
+    "max-size": "{{ docker_log_size }}",
+    "max-file": "{{ docker_log_files_amount }}"
   },
   "storage-driver": "overlay2"
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
  * [ ] Tests for the changes have been added (for bug fixes / features)
  * [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
When the service log size reaches 100mb the entire file is deleted to free up space

* **What is the new behavior (if this is a feature change)?**
Instead of just having a 100mb log file we would break this down into five 20mb files. That way when the 100mb limit is reached the oldest log file will be deleted freeing up 20mb of space. This will ensure at least 80mb of the most recent logs will be saved.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
Yes, this PR is connected to dojot/dojot#2062

* **Other information**:
