### PR TITLE
Change certificate acl label to dojot

### DIFF
--- a/roles/certificate-acl/templates/certificate_acl_deployment.yaml.j2
+++ b/roles/certificate-acl/templates/certificate_acl_deployment.yaml.j2
@@ -60,7 +60,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: dojot.components/vernemq
+              - key: dojot.components/dojot
                 operator: In
                 values:
                 - "enabled"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
  * [ ] Tests for the changes have been added (for bug fixes / features)
  * [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
If you try to deploy dojot in a k8s cluster with two worker nodes and with node affinity, and if you deploy cetificate ACL in a different node than the one with dojot services, the certificate ACL service will not work.
Certificate ACL volume label is dojot and the service label is vernemq. This is causing the bug.

* **What is the new behavior (if this is a feature change)?**
Now all Certificate ACL labels are `dojot`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
dojot/dojot#2324

* **Other information**:
