### PR TITLE
add autoscaling using keda for vernemq, k2v and v2k services

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -92,6 +92,15 @@
   roles:
     - role: kafka
 
+# Deploy Keda to the environment
+- hosts: dojot-k8s[0]
+  any_errors_fatal: true
+  tags:
+    - keda
+    - 100k
+  roles:
+    - role: keda
+
 # Deploy VerneMQ to the environment
 # TODO: Add possibility of using an external VerneMQ by setting config variables
 # TODO: Support a HA cluster

--- a/roles/k2v-bridge/tasks/main.yaml
+++ b/roles/k2v-bridge/tasks/main.yaml
@@ -12,3 +12,4 @@
   loop:
   - "{{ lookup('template', 'k2v_bridge_service.yaml.j2') | from_yaml }}"
   - "{{ lookup('template', 'k2v_bridge_cluster.yaml.j2') | from_yaml }}"
+  - "{{ lookup('template', 'k2v_bridge_keda.yaml.j2') | from_yaml }}"

--- a/roles/k2v-bridge/templates/k2v_bridge_cluster.yaml.j2
+++ b/roles/k2v-bridge/templates/k2v_bridge_cluster.yaml.j2
@@ -37,6 +37,11 @@ spec:
           periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 3
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 200m
         env:
         - name: K2V_APP_USER_CONFIG_FILE
           value: "default.conf"
@@ -77,6 +82,11 @@ spec:
           periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 3
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 200m
         env:
         - name: CERT_SC_APP_SIDECAR_TO
           value: "k2v-bridge"

--- a/roles/k2v-bridge/templates/k2v_bridge_keda.yaml.j2
+++ b/roles/k2v-bridge/templates/k2v_bridge_keda.yaml.j2
@@ -1,0 +1,19 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: k2vbridge-scaledobject
+  namespace: {{ dojot_namespace }}
+  labels:
+    app: dojot
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    name: k2v-bridge
+    kind: StatefulSet
+  minReplicaCount: 1
+  maxReplicaCount: 21
+  triggers:
+  - type: cpu
+    metricType: Utilization
+    metadata:
+      value: "80"

--- a/roles/keda/tasks/main.yml
+++ b/roles/keda/tasks/main.yml
@@ -1,0 +1,11 @@
+- name: Add stable chart repo keda
+  kubernetes.core.helm_repository:
+    name: kedacore
+    repo_url: "https://kedacore.github.io/charts"
+
+- name: Deploy latest version of Keda chart inside keda namespace
+  kubernetes.core.helm:
+    name: keda
+    chart_ref: kedacore/keda
+    release_namespace: keda
+    create_namespace: true

--- a/roles/v2k-bridge/tasks/main.yaml
+++ b/roles/v2k-bridge/tasks/main.yaml
@@ -11,3 +11,4 @@
   loop:
   - "{{ lookup('template', 'v2k_bridge_cluster.yaml.j2') | from_yaml }}"
   - "{{ lookup('template', 'v2k_bridge_service.yaml.j2') | from_yaml }}"
+  - "{{ lookup('template', 'v2k_bridge_keda.yaml.j2') | from_yaml }}"

--- a/roles/v2k-bridge/templates/v2k_bridge_cluster.yaml.j2
+++ b/roles/v2k-bridge/templates/v2k_bridge_cluster.yaml.j2
@@ -37,6 +37,11 @@ spec:
           periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 3
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 200m
         env:
         - name: V2K_APP_USER_CONFIG_FILE
           value: "default.conf"
@@ -77,6 +82,11 @@ spec:
           periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 3
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 200m
         env:
         - name: CERT_SC_APP_SIDECAR_TO
           value: "v2k-bridge"

--- a/roles/v2k-bridge/templates/v2k_bridge_keda.yaml.j2
+++ b/roles/v2k-bridge/templates/v2k_bridge_keda.yaml.j2
@@ -1,0 +1,19 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: v2k-scaledobject
+  namespace: {{ dojot_namespace }}
+  labels:
+    app: dojot
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    name: v2k-bridge
+    kind: StatefulSet
+  minReplicaCount: 1
+  maxReplicaCount: 21
+  triggers:
+  - type: cpu
+    metricType: Utilization
+    metadata:
+      value: "80"

--- a/roles/vernemq/defaults/main.yaml
+++ b/roles/vernemq/defaults/main.yaml
@@ -1,3 +1,3 @@
 dojot_verne_version: "{{ dojot_version }}"
 
-dojot_verne_operator_version: 202203171500
+dojot_verne_operator_version: 202206091125

--- a/roles/vernemq/tasks/main.yaml
+++ b/roles/vernemq/tasks/main.yaml
@@ -20,3 +20,4 @@
   - "{{ lookup('template', 'vernemq_external_service.yaml.j2') | from_yaml }}"
   - "{{ lookup('template', 'vernemq_serviceAccount.yaml.j2') | from_yaml }}"
   - "{{ lookup('template', 'z_vernemq_cluster.yaml.j2') | from_yaml }}"
+  - "{{ lookup('template', 'vernemq_hpa_cluster_keda.yaml.j2') | from_yaml }}"

--- a/roles/vernemq/templates/vernemq_hpa_cluster_keda.yaml.j2
+++ b/roles/vernemq/templates/vernemq_hpa_cluster_keda.yaml.j2
@@ -1,0 +1,19 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: vernemqcluster-scaledobject
+  namespace: {{ dojot_namespace }}
+  labels:
+    app: dojot
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    name: vernemq-k8s
+    kind: StatefulSet
+  minReplicaCount: 1
+  maxReplicaCount: 30
+  triggers:
+  - type: cpu
+    metricType: Utilization
+    metadata:
+      value: "80"

--- a/roles/vernemq/templates/vernemq_operator_deployment.yaml.j2
+++ b/roles/vernemq/templates/vernemq_operator_deployment.yaml.j2
@@ -35,6 +35,11 @@ spec:
         # https://github.com/dojot/vmq-operator/commit/8060622dbdb4a6203feee4d43fd93549a4ad4108
         image: dojot/vmq-operator-dojot:{{ dojot_verne_operator_version }}
         name: vmq-operator
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 200m
       nodeSelector:
         beta.kubernetes.io/os: linux
       securityContext:

--- a/roles/vernemq/templates/z_vernemq_cluster.yaml.j2
+++ b/roles/vernemq/templates/z_vernemq_cluster.yaml.j2
@@ -31,6 +31,11 @@ spec:
       port: 1888
       websocket: true
     plugins: []
+  resources:
+    limits:
+      cpu: 500m
+    requests:
+      cpu: 200m
   sidecarBaseImage: dojot/cert-sidecar
   sidecarEnv:
     - name: CERT_SC_APP_SIDECAR_TO
@@ -53,6 +58,11 @@ spec:
       value: "cabundle.crt"
     - name: CERT_SC_CRON_CABUNDLE
       value: "true"
+  sidecarResources:
+    limits:
+      cpu: 500m
+    requests:
+      cpu: 200m
   serviceAccountName: vernemq-k8s
 {% if dojot_enable_node_affinity %}
   nodeSelector:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
  * [ ] Tests for the changes have been added (for bug fixes / features)
  * [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
      A new feature for autoscaling vernemq, k2v and v2k services.
* **What is the current behavior?** (You can also link to an open issue here)
     the current behavior is that the pods are not autoscalable
* **What is the new behavior (if this is a feature change)?**
    the new behavior is that the pods are autoscalable for vernemq, k2v and v2k services.
* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
   No.
* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
   No.
* **Other information**:
